### PR TITLE
Update stixu.css to use locally hosted Josefin Sans.

### DIFF
--- a/styles/stixu.css
+++ b/styles/stixu.css
@@ -20,7 +20,7 @@
 /*Edit-open 619*/
 /*------------*/
 
-@import url('https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@600&display=swap');
+@import url('./josefin_sans.css');
 
 html {
     overflow-y: scroll;


### PR DESCRIPTION
It was brought to my attention that Google Fonts use tracking cookies.